### PR TITLE
Resolve "Change type of returned ID when retrieving IDs to string, date_time_properties_names should not be required when extracting clinical text"

### DIFF
--- a/doc/rest-spec/v1/mexplorer-openapi.yaml
+++ b/doc/rest-spec/v1/mexplorer-openapi.yaml
@@ -150,8 +150,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: integer
-                  format: int64
+                  type: string
 components:
   schemas:
     TableStats:
@@ -307,7 +306,6 @@ components:
         - clinical_text_entity_name
         - text_property_name
         - clinical_text_enity_id_property_name
-        - date_time_properties_names
         - root_entities_spec
       properties:
         clinical_text_entity_name:


### PR DESCRIPTION
closes #3 